### PR TITLE
es5.1記法にする

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 //@flow
 /*::
 type Query = string | number | (any) => boolean;
@@ -5,21 +9,21 @@ type Collection<T> = Array<T> | {[key: string]: Collection<T>} | T;
 type Mapper<T> = (T) => T;
 */
 
-const assign = require('lodash.assign');
-const findIndex = require('lodash.findindex');
+var assign = require('lodash.assign');
+var findIndex = require('lodash.findindex');
 
-function update/*:: <T: Collection<any>>*/(collection/*: T*/, queryList/*: Query[]*/, mapper/*: Mapper<any>*/)/*: T*/ {
+function update /*:: <T: Collection<any>>*/(collection /*: T*/, queryList /*: Query[]*/, mapper /*: Mapper<any>*/) /*: T*/{
 
   if (queryList.length === 0) {
     return mapper(collection);
   }
 
-  const rootCollection = Array.isArray(collection) ? collection.slice() : assign({}, collection);
-  const query = queryList[0];
-  let updateTarget;
+  var rootCollection = Array.isArray(collection) ? collection.slice() : assign({}, collection);
+  var query = queryList[0];
+  var updateTarget = void 0;
 
   if (Array.isArray(rootCollection)) {
-    let index/*: number*/ = -1;
+    var index /*: number*/ = -1;
     if (typeof query === 'number') {
       updateTarget = rootCollection[query];
       index = query;
@@ -27,25 +31,25 @@ function update/*:: <T: Collection<any>>*/(collection/*: T*/, queryList/*: Query
       index = findIndex(rootCollection, query);
       updateTarget = rootCollection[index];
     } else {
-      throw new Error(`query type must be number or function for Array. '${typeof query}' was given`);
+      throw new Error('query type must be number or function for Array. \'' + (typeof query === 'undefined' ? 'undefined' : _typeof(query)) + '\' was given');
     }
 
     if (!updateTarget) {
-      throw new Error(`target not found with query '${query.toString()}'`);
+      throw new Error('target not found with query \'' + query.toString() + '\'');
     }
 
     rootCollection[index] = update(updateTarget, queryList.slice(1), mapper);
   } else {
-    const key = query.toString();
+    var key = query.toString();
 
     if (typeof query === 'string' || typeof query === 'number') {
       updateTarget = rootCollection[key];
     } else {
-      throw new Error(`query type must be string or number for Obect. query '${typeof query}' was given`);
+      throw new Error('query type must be string or number for Obect. query \'' + (typeof query === 'undefined' ? 'undefined' : _typeof(query)) + '\' was given');
     }
 
     if (!updateTarget) {
-      throw new Error(`target not found with query '${query.toString()}'`);
+      throw new Error('target not found with query \'' + query.toString() + '\'');
     }
 
     rootCollection[key] = update(updateTarget, queryList.slice(1), mapper);
@@ -54,4 +58,4 @@ function update/*:: <T: Collection<any>>*/(collection/*: T*/, queryList/*: Query
   return rootCollection;
 }
 
-module.exports = {update};
+module.exports = { update: update };


### PR DESCRIPTION
このモジュールを利用しているほとんどのモジュールでこのリポジトリのトランスパイルが必要な状況なので、es5.1まで利用しているシンタックスを落とす。

prepublishでトランスパイルをしてもいいが、そこまでするほど大きなモジュールではないのでやらない。